### PR TITLE
fix: Ensure strict schema definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,12 @@ class AddLambdaInsights {
       serverless.configSchemaHandler.defineCustomProperties({
         properties: {
           lambdaInsights: {
-            defaultLambdaInsights: {type: 'boolean'},
-            attachPolicy: {type: 'boolean'},
-            lambdaInsightsVersion: {type: 'number'},
+            type: 'object',
+            properties: {
+              defaultLambdaInsights: {type: 'boolean'},
+              attachPolicy: {type: 'boolean'},
+              lambdaInsightsVersion: {type: 'number'},
+            }
           },
         },
       });


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/serverless-plugin-lambda-insights/issues/17

*Description of changes:* Ensure that schema definitions are valid according to strict schema validation rules


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
