### PR TITLE
Bugfix/allow multiple functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ class AddLambdaInsights {
           localLambdaInsights === false ||
           (localLambdaInsights === null && globalLambdaInsights === null)
         ) {
-          return;
+          continue;
         }
 
         const fnLambdaInsights = localLambdaInsights || globalLambdaInsights;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-insights",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-insights",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-insights",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A Serverless Framework Plugin allowing to enable Lambda Insights for entire Serverless stack or individual functions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-insights",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A Serverless Framework Plugin allowing to enable Lambda Insights for entire Serverless stack or individual functions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
*Issue #, if available:*
[Issue 24](https://github.com/awslabs/serverless-plugin-lambda-insights/issues/24)
*Description of changes:*
Fixes issue with not allowing multiple functions in one template to configure lambda insights.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
