### PR TITLE
Fix layer generation for arm64 architecture when it's defined globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ class AddLambdaInsights {
     this.serverless = serverless;
     this.service = this.serverless.service;
     this.provider = this.serverless.getProvider('aws');
-    
     this.hooks = {
       'before:package:setupProviderConfiguration': this.addLambdaInsights.bind(this),
     };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class AddLambdaInsights {
     this.serverless = serverless;
     this.service = this.serverless.service;
     this.provider = this.serverless.getProvider('aws');
-
+    
     this.hooks = {
       'before:package:setupProviderConfiguration': this.addLambdaInsights.bind(this),
     };
@@ -95,10 +95,11 @@ class AddLambdaInsights {
    */
   async generateLayerARN(version, architecture) {
     const region = this.provider.getRegion();
+    const isArm64 = architecture === 'arm64' || this.service.provider.architecture === 'arm64';
     if (version) {
       try {
         let layerVersionInfo;
-        if (architecture === 'arm64' || this.provider.architecture === 'arm64') {
+        if (isArm64) {
           layerVersionInfo = await this.provider.request('Lambda', 'getLayerVersionByArn', {
             Arn: `arn:aws:lambda:${region}:580247275435:layer:LambdaInsightsExtension-Arm64:${version}`,
           });
@@ -120,7 +121,7 @@ class AddLambdaInsights {
     }
 
     let arn;
-    if (architecture === 'arm64' || this.provider.architecture === 'arm64') {
+    if (isArm64) {
       arn = layerVersionsArm64[region];
     } else {
       arn = layerVersions[region];

--- a/index.test.js
+++ b/index.test.js
@@ -122,16 +122,15 @@ test('addLambdaInsights adds IAM policy', async () => {
   // act
   await plugin.addLambdaInsights();
 
-  // assert
-  expect(plugin.provider.iamManagedPolicies)
+  // assert 
+  expect(plugin.service.provider.iamManagedPolicies)
       .toStrictEqual(['arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy']);
 });
 
 
 const createServerless = (region, LayerVersion) => {
-  const provider = {
+  const awsProvider = {
     getRegion: () => region,
-    iamManagedPolicies: [],
     request: async (service, method, param) => {
       // explicit layer version test is only valid for version 12
       if (param.Arn===`arn:aws:lambda:${region}:580247275435:layer:LambdaInsightsExtension:12`) {
@@ -144,13 +143,17 @@ const createServerless = (region, LayerVersion) => {
     },
   };
   return {
-    getProvider: () => provider,
+    getProvider: () => awsProvider,
     configSchemaHandler: {
       defineFunctionProperties: () => jest.fn(),
       defineCustomProperties: () => jest.fn(),
     },
     service: {
-      provider,
+      provider: {
+        name: 'aws',
+        runtime: 'nodejs12.x',
+        architecture: 'x86_64',
+      },
       custom: {
         lambdaInsights: {
           lambdaInsightsVersion: LayerVersion,


### PR DESCRIPTION
The PR fixes https://github.com/awslabs/serverless-plugin-lambda-insights/issues/28

*Description of changes:*
Currently, the globally defined `architecture` field is ignored as the code is using a provider returned by `getProvider('aws')` to receive the `architecture` value, when in reality getProvider('aws') returns a completely different thing.
My changes are addressing this incorrect usage of getProvider.

