### PR TITLE
fix: fix generate layer ARN function in case if function level archit…

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class AddLambdaInsights {
    */
   async generateLayerARN(version, architecture) {
     const region = this.provider.getRegion();
-    const isArm64 = architecture === 'arm64' || this.service.provider.architecture === 'arm64';
+    const isArm64 = architecture ? architecture === 'arm64' : this.service.provider.architecture === 'arm64';
     if (version) {
       try {
         let layerVersionInfo;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```
provider:
    name: aws
    runtime: nodejs12.x
    architecture: arm64

functions:
   hello:
      handler: handler.hello
      architecture: x86_64
      lambdaInsights: true
```

Currently in this case plugin selects wrong type of lambda layer based on provider level **architecture**.
After this fix it will select the right lambda layer version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
